### PR TITLE
one-way permanence

### DIFF
--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -128,7 +128,7 @@ module SslRequirement
     elsif request.ssl? && ssl_allowed?
       return true
     elsif request.ssl? && !ssl_required?
-      redirect_to determine_redirect_url(request, false), :status => (redirect_status || :found)
+      redirect_to determine_redirect_url(request, false), :status => :found
       flash.keep
       return false
     end


### PR DESCRIPTION
We don't want browsers to cache redirects to non-SSL.

This way we can have 301 redirects from non-SSL to SSL, and 302 from SSL to non-SSL.

This is a temporary patch before dropping `ssl_requirement` entirely.
